### PR TITLE
Rename Anchor to Lusitania

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-anchor
-======
+Lusitania
+=========
 
-Anchor is a javascript library that lets you define strict types.
-<!-- err todo: It also helps you validate and normalize the usage of command line scripts and even individual functions. -->
+Lusitania is a javascript library that lets you define strict types.
 
 This makes it really useful for things like:
 + Form validation on the client or server
@@ -12,20 +11,15 @@ This makes it really useful for things like:
 + Normalizing polymorphic behaviors
 
 Adds support for strongly typed arguments, like http://lea.verou.me/2011/05/strongly-typed-javascript/, but goes a step further by adding support for array and object sub-validation.
-It's also the core validation library for the Sails ecosystem. 
+It's also the core validation library for the Sails ecosystem.
 
 (Built on top of the great work with https://github.com/chriso/validator.js)
 
 ## Installation
 
-### Client-side
-```html
-<script type='text/javscript' src="/js/anchor.js"></script>
-```
-
 ### node.js
 ```bash
-npm install anchor
+npm install lusitania@git://github.com/Shyp/lusitania.git#master
 ```
 
 <!--
@@ -137,13 +131,13 @@ anchor(userData).to({
   email: 'email',
   twitterHandle: 'twitter',
   homepage: 'url',
-  
+
   // This requires any data
   someData: {},
-  
+
   // This will require a list of >=0 hex colors
   favoriteColors: ['htmlcolor'],
-  
+
   // This will require a list of >=0 badge objects, as defined:
   badges: [{
     name: 'string',
@@ -188,7 +182,7 @@ $.get = anchor($.get).usage(
 
 ### Multiple usages and Argument normalization
 
-But sometimes you want to support several different argument structures.  
+But sometimes you want to support several different argument structures.
 And to do that, you have to, either explicitly or implicitly, name those arguments so your function can know which one was which, irrespective of how the arguments are specified.
 Here's how you specify multiple usages:
 
@@ -204,20 +198,20 @@ var getById = anchor(
       id: args.id
     }, args.done);
   })
-  
-  // Here you can define your named arguments as temporal custom data types, 
+
+  // Here you can define your named arguments as temporal custom data types,
   // each with their OWN validation rules
   .args({
     endpoint: 'urlish',
     id: 'int'
     done: 'function'
   })
-  
+
   // To pass valiation, the user arguments must match at least one of the usages below
   // and each argument must pass its validation definition above
   .usage(
     ['endpoint', 'id', 'done'],
-    
+
     // Callback is optional
     ['endpoint', 'id']
   );
@@ -264,7 +258,7 @@ anchor(myFunction)
     options: {}
   })
   .defaults({
-    
+
   }),
   .usage(
     ['id'],
@@ -295,27 +289,27 @@ function createUser (req,res,next) {
     id: 'int',
     name: 'string'
   });
-  
-  
+
+
   // Do stuff here
-  // This could be anything-- we chose to demonstrate a create method 
+  // This could be anything-- we chose to demonstrate a create method
   // in this case from our favorite ORM, Waterline (http://github.com/mikermcneil/waterline)
    async.auto([
-        
+
       // Create the user itself
       user: User.create(params).done,
-      
+
       // Grant permission for the user to administer itself
       permission: Permission.create({
         targetModel : 'user',
         targetId    : params.id,
         UserId      : params.id,
       }).done
-      
+
     ], function (err, results) {
-    
+
       // Just basic usage, but this prevents you from dealing with non-existent values and null pointers
-      // both when providing a consistent API on the server-side 
+      // both when providing a consistent API on the server-side
       // AND when marshalling server-sent data on the client-side
       // i.e. this sucks: user.friends && user.friends.length && user.friends[0] && user.friends[0].id
       var user = res.anchor(results.user).to({
@@ -328,10 +322,10 @@ function createUser (req,res,next) {
           email: 'string'
         }]
       });
-      
+
       // Respond with JSON
-      // Could just pass the user object, 
-      // but in this case we're demonstrating a custom mapping 
+      // Could just pass the user object,
+      // but in this case we're demonstrating a custom mapping
       // (like you might use to implement a custom, predefined API)
       // You can safely know all the .'s you're using won't result in any errors, since you validated this above
       res.json({
@@ -341,7 +335,7 @@ function createUser (req,res,next) {
         friends           : user.friends
       });
   });
-  
+
 }
 ```
 
@@ -358,13 +352,13 @@ Here's an example of how you might right your `create()` action to comply with a
 
 var UserController = {
   create: {
-    
-    // Marshal the request 
+
+    // Marshal the request
     request   : {
       id    : 'int',
       name  : 'string'
     },
-    
+
     // Marshal the response to use the predetermined API
     response  : {
       user_id             : 'user.id'
@@ -372,7 +366,7 @@ var UserController = {
       user_email_address  : 'user.email'
       friends             : 'user.friends'
     },
-    
+
     // Define an arbitrarily named attribute that will be used in response
     // and the function that will populate it
     // The function will be called with the entire request object as the first parameter
@@ -390,7 +384,7 @@ The model validation also uses anchor:
 // User.js
 var User = {
   adapter: 'mongo',
-  
+
   attributes: {
     id: 'int',
     name: 'string',
@@ -401,22 +395,22 @@ var User = {
       email: 'string'
     }]
   },
-  
+
   // Create a user, but also create the permission for it to manage itself
   create: function (values,cb) {
-    
+
     async.auto({
-      
+
       // Create the user itself
       user: User.create(values).done,
-      
+
       // Grant permission for the user to administer itself
       permission: Permission.create({
         targetModel : 'user',
         targetId    : values.id,
         UserId      : values.id,
       }).done
-      
+
     ], function (err, results) {
       cb(err, results.user);
     });
@@ -451,4 +445,3 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 [![githalytics.com alpha](https://cruel-carlota.pagodabox.com/18e6e2459aed1edbdee85d77d63b623b "githalytics.com")](http://githalytics.com/balderdashy/anchor)
-

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var sanitize = require('validator').sanitize;
  */
 
 module.exports = function (entity) {
-	return new Anchor(entity);
+	return new Lusitania(entity);
 };
 
 
@@ -21,14 +21,14 @@ module.exports = function (entity) {
 
 
 /**
- * Constructor of individual instance of Anchor
- * Specify the function, object, or list to be anchored
+ * Constructor of individual instance of Lusitania
+ * Specify the function, object, or list to be lusitaniaed
  */
 
-function Anchor (entity) {
+function Lusitania (entity) {
 	if (util.isFunction(entity)) {
 		this.fn = entity;
-		throw new Error ('Anchor does not support functions yet!');
+		throw new Error ('Lusitania does not support functions yet!');
 	}
 	else this.data = entity;
 
@@ -43,7 +43,7 @@ function Anchor (entity) {
  * Built-in data type rules
  */
 
-Anchor.prototype.rules = require('./lib/match/rules');
+Lusitania.prototype.rules = require('./lib/match/rules');
 
 
 
@@ -53,7 +53,7 @@ Anchor.prototype.rules = require('./lib/match/rules');
  * Enforce that the data matches the specified ruleset
  */
 
-Anchor.prototype.to = function (ruleset, context) {
+Lusitania.prototype.to = function (ruleset, context) {
 
 	var errors = [];
 
@@ -68,12 +68,12 @@ Anchor.prototype.to = function (ruleset, context) {
 
 			// Use deep match to descend into the collection and verify each item and/or key
 			// Stop at default maxDepth (50) to prevent infinite loops in self-associations
-			errors = errors.concat(Anchor.match.type.call(context, this.data, ruleset['type']));
+			errors = errors.concat(Lusitania.match.type.call(context, this.data, ruleset['type']));
 		}
 
 		// Validate a non-type rule
 		else {
-			errors = errors.concat(Anchor.match.rule.call(context, this.data, rule, ruleset[rule]));
+			errors = errors.concat(Lusitania.match.rule.call(context, this.data, rule, ruleset[rule]));
 		}
 	}
 
@@ -86,7 +86,7 @@ Anchor.prototype.to = function (ruleset, context) {
 	else return false;
 
 };
-Anchor.prototype.hasErrors = Anchor.prototype.to;
+Lusitania.prototype.hasErrors = Lusitania.prototype.to;
 
 
 
@@ -116,7 +116,7 @@ Anchor.prototype.hasErrors = Anchor.prototype.to;
 
 	}
  *
- * Adapter developers would be able to use Anchor.prototype.cast()
+ * Adapter developers would be able to use Lusitania.prototype.cast()
  * to declaritively define these type coercions.
 
  * Down the line, we could take this further for an even nicer API,
@@ -124,7 +124,7 @@ Anchor.prototype.hasErrors = Anchor.prototype.to;
  *
  */
 
-Anchor.prototype.cast = function (ruleset) {
+Lusitania.prototype.cast = function (ruleset) {
 	todo();
 };
 
@@ -135,7 +135,7 @@ Anchor.prototype.cast = function (ruleset) {
  * Coerce the data to the specified ruleset no matter what
  */
 
-Anchor.prototype.hurl = function (ruleset) {
+Lusitania.prototype.hurl = function (ruleset) {
 
 	// Iterate trough given data attributes
 	// to check if they exist in the ruleset
@@ -156,7 +156,7 @@ Anchor.prototype.hurl = function (ruleset) {
 
 	// Once we make sure that attributes match
 	// we can just proceed to deepMatch
-	Anchor.match(this.data, ruleset, this);
+	Lusitania.match(this.data, ruleset, this);
 };
 
 
@@ -167,7 +167,7 @@ Anchor.prototype.hurl = function (ruleset) {
  * Specify default values to automatically populated when undefined
  */
 
-Anchor.prototype.defaults = function (ruleset) {
+Lusitania.prototype.defaults = function (ruleset) {
 	todo();
 };
 
@@ -185,7 +185,7 @@ Anchor.prototype.defaults = function (ruleset) {
  * @param {Object|Function}	definition
  */
 
-Anchor.prototype.define = function (name, definition) {
+Lusitania.prototype.define = function (name, definition) {
 
 	// check to see if we have an dictionary
 	if ( util.isObject(name) ) {
@@ -198,7 +198,7 @@ Anchor.prototype.define = function (name, definition) {
 		}
 
 		// add the new custom data types
-		util.extend(Anchor.prototype.rules, name);
+		util.extend(Lusitania.prototype.rules, name);
 
 		return this;
 
@@ -207,7 +207,7 @@ Anchor.prototype.define = function (name, definition) {
 	if ( util.isFunction(definition) && util.isString(name) ) {
 
 		// Add a single data type
-		Anchor.prototype.rules[name] = definition;
+		Lusitania.prototype.rules[name] = definition;
 
 		return this;
 
@@ -224,7 +224,7 @@ Anchor.prototype.define = function (name, definition) {
  * Specify custom ruleset
  */
 
-Anchor.prototype.as = function (ruleset) {
+Lusitania.prototype.as = function (ruleset) {
 	todo();
 };
 
@@ -235,7 +235,7 @@ Anchor.prototype.as = function (ruleset) {
  * Specify named arguments and their rulesets as an object
  */
 
-Anchor.prototype.args = function (args) {
+Lusitania.prototype.args = function (args) {
 	todo();
 };
 
@@ -246,7 +246,7 @@ Anchor.prototype.args = function (args) {
  * Specify each of the permitted usages for this function
  */
 
-Anchor.prototype.usage = function () {
+Lusitania.prototype.usage = function () {
 	var usages = util.toArray(arguments);
 	todo();
 };
@@ -258,7 +258,7 @@ Anchor.prototype.usage = function () {
  * Deep-match a complex collection or model against a schema
  */
 
-Anchor.match = require('./lib/match');
+Lusitania.match = require('./lib/match');
 
 
 
@@ -268,7 +268,7 @@ Anchor.match = require('./lib/match');
  * Expose `define` so it can be used globally
  */
 
-module.exports.define = Anchor.prototype.define;
+module.exports.define = Lusitania.prototype.define;
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "anchor",
+  "name": "lusitania",
   "version": "0.10.2",
   "description": "Recursive validation library with support for objects and lists",
-  "homepage": "http://sailsjs.org",
+  "homepage": "https://api.shyp.com",
   "keywords": [
     "validation",
     "recursive-validator",
@@ -25,9 +25,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/balderdashy/anchor.git"
+    "url": "git://github.com/Shyp/lusitania.git"
   },
-  "author": "Mike McNeil",
+  "author": "Shyp Engineering",
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
@@ -36,6 +36,6 @@
   },
   "devDependencies": {
     "async": "~0.2.10",
-    "mocha": "1.9.x"
+    "mocha": "^2"
   }
 }

--- a/test/arrayType.test.js
+++ b/test/arrayType.test.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var anchor = require('../index.js');
+var lusitania = require('../index.js');
 var testType = require('./util/testType.js');
 
 describe('arrays', function() {

--- a/test/basicType.test.js
+++ b/test/basicType.test.js
@@ -1,13 +1,13 @@
 var _ = require('lodash');
-var anchor = require('../index.js');
+var lusitania = require('../index.js');
 var testType = require('./util/testType.js');
 
 
 
 describe('basic rules', function() {
 
-	it('should create an anchor object in naive usage',function () {
-		anchor('foo');
+	it('should create an lusitania object in naive usage',function () {
+		lusitania('foo');
 		return true;
 	});
 

--- a/test/customMessages.test.js
+++ b/test/customMessages.test.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var anchor = require('../index.js');
+var lusitania = require('../index.js');
 var testType = require('./util/testType.js');
 var assert = require('assert');
 
@@ -7,8 +7,8 @@ var assert = require('assert');
 describe('custom validation messages ($message syntax)', function() {
 
   it(' should use custom validation message when `$message` is a string', function() {
-    
-    var errors = anchor({
+
+    var errors = lusitania({
       name: 'Sebastian',
       id: '235',
       friends: 'd'
@@ -55,7 +55,7 @@ describe('custom validation messages ($message syntax)', function() {
         case 'id': return err.message === 'oops1';
         case 'friends': return err.message === 'oops2';
         case 'moreFriends': return err.message === 'oops3';
-        
+
         // Check for proper usage error:
         case 'foo': return err.status === 500 && err.code === 'E_USAGE' && err.$message === 'oops4';
         default: return false;

--- a/test/defineType.test.js
+++ b/test/defineType.test.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var anchor = require('../index.js');
+var lusitania = require('../index.js');
 var async = require('async');
 var assert = require("assert");
 
@@ -18,7 +18,7 @@ describe('Custom Types', function() {
 				return val === 5;
 			};
 
-			assert.equal(false, anchor(example).define("five", isfive).to({type:rules}));
+			assert.equal(false, lusitania(example).define("five", isfive).to({type:rules}));
 		});
 	});
 
@@ -42,7 +42,7 @@ describe('Custom Types', function() {
 				}
 			};
 
-			assert.equal(false, anchor(example).define(definition).to({type:rules}));
+			assert.equal(false, lusitania(example).define(definition).to({type:rules}));
 		});
 	});
 
@@ -50,11 +50,11 @@ describe('Custom Types', function() {
 		it(' should support providing context for rules via',function () {
 			var user = { password: 'passW0rd', passwordConfirmation: 'passW0rd' };
 
-			anchor.define('password', function (password) {
+			lusitania.define('password', function (password) {
 				return password === this.passwordConfirmation;
 			});
 
-			var outcome = anchor(user.password).to({ type: 'password' }, user);
+			var outcome = lusitania(user.password).to({ type: 'password' }, user);
 
 			assert.equal(false, outcome);
 		});

--- a/test/miscellaneousRules.test.js
+++ b/test/miscellaneousRules.test.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var anchor = require('../index.js');
+var lusitania = require('../index.js');
 var testRules = require('./util/testRules.js');
 
 

--- a/test/nestedRules.test.js
+++ b/test/nestedRules.test.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var anchor = require('../index.js');
+var lusitania = require('../index.js');
 var testType = require('./util/testType.js');
 
 describe('nested rules ($validate syntax)', function() {

--- a/test/objectType.test.js
+++ b/test/objectType.test.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var anchor = require('../index.js');
+var lusitania = require('../index.js');
 var testType = require('./util/testType.js');
 
 describe('objects', function() {

--- a/test/util/testRules.js
+++ b/test/util/testRules.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var anchor = require('../../index.js');
+var lusitania = require('../../index.js');
 var async = require('async');
 
 // Test a rule given a deliberate example and nonexample
@@ -11,10 +11,10 @@ module.exports = function testRules (rules, example, nonexample) {
 	var exampleOutcome, nonexampleOutcome;
 
 	// Should be falsy
-	exampleOutcome = anchor(example).to(rules);
+	exampleOutcome = lusitania(example).to(rules);
 
 	// Should be an array
-	nonexampleOutcome = anchor(nonexample).to(rules);
+	nonexampleOutcome = lusitania(nonexample).to(rules);
 
 	if (exampleOutcome) {
 		return gotErrors('Valid input marked with error!', exampleOutcome, example);

--- a/test/util/testType.js
+++ b/test/util/testType.js
@@ -1,5 +1,5 @@
 var _ = require('lodash');
-var anchor = require('../../index.js');
+var lusitania = require('../../index.js');
 var async = require('async');
 
 // Test a rule given a deliberate example and nonexample
@@ -11,12 +11,12 @@ module.exports = function testType (rule, example, nonexample) {
 	var exampleOutcome, nonexampleOutcome;
 
 	// Should be falsy
-	exampleOutcome = anchor(example).to({
+	exampleOutcome = lusitania(example).to({
 		type: rule
 	});
 
 	// Should be an array
-	nonexampleOutcome = anchor(nonexample).to({
+	nonexampleOutcome = lusitania(nonexample).to({
 		type: rule
 	});
 


### PR DESCRIPTION
The name "anchor" conflicts with an internal name, so let's change it to avoid
confusion. Updates all references in the code as well to point to the new name.
