### PR TITLE
Don't print out that null is an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,89 +1,79 @@
 /**
- * Module dependencies
- */
+* Module dependencies
+*/
 
 var util = require('lodash');
 var sanitize = require('validator').sanitize;
 
-
-
-
 /**
- * Public access
- */
+* Public access
+*/
 
 module.exports = function (entity) {
-	return new Lusitania(entity);
+  return new Lusitania(entity);
 };
 
-
-
-
-
 /**
- * Constructor of individual instance of Lusitania
- * Specify the function, object, or list to be lusitaniaed
- */
+* Constructor of individual instance of Lusitania
+* Specify the function, object, or list to be lusitaniaed
+*/
 
 function Lusitania (entity) {
-	if (util.isFunction(entity)) {
-		this.fn = entity;
-		throw new Error ('Lusitania does not support functions yet!');
-	}
-	else this.data = entity;
+  if (util.isFunction(entity)) {
+    this.fn = entity;
+    throw new Error ('Lusitania does not support functions yet!');
+  }
+  else this.data = entity;
 
-	return this;
+  return this;
 }
 
-
-
-
-
 /**
- * Built-in data type rules
- */
+* Built-in data type rules
+*/
 
 Lusitania.prototype.rules = require('./lib/match/rules');
 
-
-
-
-
 /**
- * Enforce that the data matches the specified ruleset
- */
+* Enforce that the data matches the specified ruleset
+*/
 
 Lusitania.prototype.to = function (ruleset, context) {
 
-	var errors = [];
+  var errors = [];
 
-	// If ruleset doesn't contain any explicit rule keys,
-	// assume that this is a type
+  // If ruleset doesn't contain any explicit rule keys,
+  // assume that this is a type
 
+  var validation;
+  if (typeof context !== "undefined" && typeof context.validation !== "undefined") {
+    validation = context.validation;
+  } else {
+    validation = 'field';
+  }
+  // Look for explicit rules
+  for (var rule in ruleset) {
 
-	// Look for explicit rules
-	for (var rule in ruleset) {
+    if (rule === 'type') {
 
-		if (rule === 'type') {
+      // Use deep match to descend into the collection and verify each item and/or key
+      // Stop at default maxDepth (50) to prevent infinite loops in self-associations
+      errors = errors.concat(Lusitania.match.type.call(context, this.data, ruleset.type, null, validation));
+    }
 
-			// Use deep match to descend into the collection and verify each item and/or key
-			// Stop at default maxDepth (50) to prevent infinite loops in self-associations
-			errors = errors.concat(Lusitania.match.type.call(context, this.data, ruleset['type']));
-		}
+    // Validate a non-type rule
+    else {
+      errors = errors.concat(Lusitania.match.rule.call(context, this.data, rule, ruleset[rule]));
+    }
+  }
 
-		// Validate a non-type rule
-		else {
-			errors = errors.concat(Lusitania.match.rule.call(context, this.data, rule, ruleset[rule]));
-		}
-	}
+  // If errors exist, return the list of them
+  if (errors.length) {
+    return errors;
+  }
 
-	// If errors exist, return the list of them
-	if (errors.length) {
-		return errors;
-	}
-
-	// No errors, so return false
-	else return false;
+  // No errors, so return false
+  else return false;
 
 };
 Lusitania.prototype.hasErrors = Lusitania.prototype.to;
@@ -93,70 +83,70 @@ Lusitania.prototype.hasErrors = Lusitania.prototype.to;
 
 
 /**
- * Coerce the data to the specified ruleset if possible
- * otherwise throw an error
- * Priority: this should probably provide the default
- * implementation in Waterline core.  Currently it's completely
- * up to the adapter to define type coercion.
- *
- * Which is fine!.. but complicates custom CRUD adapter development.
- * Much handier would be an evented architecture, that allows
- * for adapter developers to write:
- *
-	{
-		// Called before find() receives criteria
-		// Here, criteria refers to just attributes (the `where`)
-		// limit, skip, and sort are not included
-		coerceCriteria: function (criteria) {
-			return criteria;
-		},
+* Coerce the data to the specified ruleset if possible
+* otherwise throw an error
+* Priority: this should probably provide the default
+* implementation in Waterline core.  Currently it's completely
+* up to the adapter to define type coercion.
+*
+* Which is fine!.. but complicates custom CRUD adapter development.
+* Much handier would be an evented architecture, that allows
+* for adapter developers to write:
+*
+{
+// Called before find() receives criteria
+// Here, criteria refers to just attributes (the `where`)
+// limit, skip, and sort are not included
+coerceCriteria: function (criteria) {
+return criteria;
+},
 
-		// Called before create() or update() receive values
-		coerceValues: function () {}
+// Called before create() or update() receive values
+coerceValues: function () {}
 
-	}
- *
- * Adapter developers would be able to use Lusitania.prototype.cast()
- * to declaritively define these type coercions.
+}
+*
+* Adapter developers would be able to use Lusitania.prototype.cast()
+* to declaritively define these type coercions.
 
- * Down the line, we could take this further for an even nicer API,
- * but for now, this alone would be a nice improvement.
- *
- */
+* Down the line, we could take this further for an even nicer API,
+* but for now, this alone would be a nice improvement.
+*
+*/
 
 Lusitania.prototype.cast = function (ruleset) {
-	todo();
+  todo();
 };
 
 
 
 
 /**
- * Coerce the data to the specified ruleset no matter what
- */
+* Coerce the data to the specified ruleset no matter what
+*/
 
 Lusitania.prototype.hurl = function (ruleset) {
 
-	// Iterate trough given data attributes
-	// to check if they exist in the ruleset
-	for (var attr in this.data) {
-		if (this.data.hasOwnProperty(attr)) {
+  // Iterate trough given data attributes
+  // to check if they exist in the ruleset
+  for (var attr in this.data) {
+    if (this.data.hasOwnProperty(attr)) {
 
-			// If it doesnt...
-			if (!ruleset[attr]) {
+      // If it doesnt...
+      if (!ruleset[attr]) {
 
-				// Declaring err here as error helpers live in match.js
-				var err = new Error('Validation error: Attribute \"' + attr + '\" is not in the ruleset.');
+        // Declaring err here as error helpers live in match.js
+        var err = new Error('Validation error: Attribute \"' + attr + '\" is not in the ruleset.');
 
-				// just throw it
-				throw err;
-			}
-		}
-	}
+        // just throw it
+        throw err;
+      }
+    }
+  }
 
-	// Once we make sure that attributes match
-	// we can just proceed to deepMatch
-	Lusitania.match(this.data, ruleset, this);
+  // Once we make sure that attributes match
+  // we can just proceed to deepMatch
+  Lusitania.match(this.data, ruleset, this);
 };
 
 
@@ -164,11 +154,11 @@ Lusitania.prototype.hurl = function (ruleset) {
 
 
 /**
- * Specify default values to automatically populated when undefined
- */
+* Specify default values to automatically populated when undefined
+*/
 
 Lusitania.prototype.defaults = function (ruleset) {
-	todo();
+  todo();
 };
 
 
@@ -176,44 +166,44 @@ Lusitania.prototype.defaults = function (ruleset) {
 
 
 /**
- * Declare a custom data type
- * If function definition is specified, `name` is required.
- * Otherwise, if dictionary-type `definition` is specified,
- * `name` must not be present.
- *
- * @param {String} name				[optional]
- * @param {Object|Function}	definition
- */
+* Declare a custom data type
+* If function definition is specified, `name` is required.
+* Otherwise, if dictionary-type `definition` is specified,
+* `name` must not be present.
+*
+* @param {String} name				[optional]
+* @param {Object|Function}	definition
+*/
 
 Lusitania.prototype.define = function (name, definition) {
 
-	// check to see if we have an dictionary
-	if ( util.isObject(name) ) {
+  // check to see if we have an dictionary
+  if ( util.isObject(name) ) {
 
-		// if so all the attributes should be validation functions
-		for (var attr in name){
-			if(!util.isFunction(name[attr])){
-				throw new Error('Definition error: \"' + attr + '\" does not have a definition');
-			}
-		}
+    // if so all the attributes should be validation functions
+    for (var attr in name){
+      if(!util.isFunction(name[attr])){
+        throw new Error('Definition error: \"' + attr + '\" does not have a definition');
+      }
+    }
 
-		// add the new custom data types
-		util.extend(Lusitania.prototype.rules, name);
+    // add the new custom data types
+    util.extend(Lusitania.prototype.rules, name);
 
-		return this;
+    return this;
 
-	}
+  }
 
-	if ( util.isFunction(definition) && util.isString(name) ) {
+  if ( util.isFunction(definition) && util.isString(name) ) {
 
-		// Add a single data type
-		Lusitania.prototype.rules[name] = definition;
+    // Add a single data type
+    Lusitania.prototype.rules[name] = definition;
 
-		return this;
+    return this;
 
-	}
+  }
 
-	throw new Error('Definition error: \"' + name + '\" is not a valid definition.');
+  throw new Error('Definition error: \"' + name + '\" is not a valid definition.');
 };
 
 
@@ -221,42 +211,42 @@ Lusitania.prototype.define = function (name, definition) {
 
 
 /**
- * Specify custom ruleset
- */
+* Specify custom ruleset
+*/
 
 Lusitania.prototype.as = function (ruleset) {
-	todo();
+  todo();
 };
 
 
 
 
 /**
- * Specify named arguments and their rulesets as an object
- */
+* Specify named arguments and their rulesets as an object
+*/
 
 Lusitania.prototype.args = function (args) {
-	todo();
+  todo();
 };
 
 
 
 
 /**
- * Specify each of the permitted usages for this function
- */
+* Specify each of the permitted usages for this function
+*/
 
 Lusitania.prototype.usage = function () {
-	var usages = util.toArray(arguments);
-	todo();
+  var usages = util.toArray(arguments);
+  todo();
 };
 
 
 
 
 /**
- * Deep-match a complex collection or model against a schema
- */
+* Deep-match a complex collection or model against a schema
+*/
 
 Lusitania.match = require('./lib/match');
 
@@ -265,8 +255,8 @@ Lusitania.match = require('./lib/match');
 
 
 /**
- * Expose `define` so it can be used globally
- */
+* Expose `define` so it can be used globally
+*/
 
 module.exports.define = Lusitania.prototype.define;
 
@@ -275,5 +265,5 @@ module.exports.define = Lusitania.prototype.define;
 
 
 function todo() {
-	throw new Error('Not implemented yet! If you\'d like to contribute, tweet @mikermcneil.');
+  throw new Error('Not implemented yet! If you\'d like to contribute, tweet @mikermcneil.');
 }

--- a/lib/match/errorFactory.js
+++ b/lib/match/errorFactory.js
@@ -8,14 +8,14 @@ var util = require('util');
 
 /**
  * `errorFactory()`
- * 
+ *
  * @param  {?} value
  * @param  {String} ruleName
  * @param  {String} keyName
  * @param  {String|Function} customMessage    (optional)
- * 
+ *
  * @return {Object}
- * 
+ *
  * @api private
  */
 
@@ -34,10 +34,17 @@ module.exports = function errorFactory(value, ruleName, keyName, customMessage) 
     // errMsg += keyName ? '(' + keyName + ') ' : '';
     // errMsg += 'is not of type "' + ruleName + '"';
 
-    errMsg = util.format(
-      '`%s` should be a %s (instead of "%s", which is a %s)',
-      keyName, ruleName, value, typeof value
-    );
+    if (value === null) {
+      errMsg = util.format(
+        '`%s` should be a %s (instead of null)',
+        keyName, ruleName
+      );
+    } else {
+      errMsg = util.format(
+        '`%s` should be a %s (instead of "%s", which is a %s)',
+        keyName, ruleName, value, typeof value
+      );
+    }
   }
 
 

--- a/lib/match/matchType.js
+++ b/lib/match/matchType.js
@@ -32,12 +32,11 @@ var MAX_DEPTH = 50;
  * @param {String} keyName
  * @param {String} customMessage
  *                   (optional)
- * 
+ *
  * @returns a list of errors (or an empty list if no errors were found)
  */
 
 function deepMatchType(data, ruleset, depth, keyName, customMessage) {
-
   var self = this;
 
   // Prevent infinite recursion
@@ -84,7 +83,7 @@ function deepMatchType(data, ruleset, depth, keyName, customMessage) {
   else {
 
     // Note:
-    // 
+    //
     // We take advantage of a couple of preconditions at this point:
     // (a) ruleset must be an Object
     // (b) ruleset must NOT be an Array
@@ -127,10 +126,10 @@ function deepMatchType(data, ruleset, depth, keyName, customMessage) {
 
       return deepMatchType.call(self, data, subValidation.type, depth+1, keyName, customMessage);
     }
-    
 
 
-    
+
+
 
     // Don't treat empty object as a ruleset
     // Instead, treat it as 'object'
@@ -157,7 +156,7 @@ function deepMatchType(data, ruleset, depth, keyName, customMessage) {
 
 /**
  * `matchType()`
- * 
+ *
  * Return whether a piece of data matches a rule
  *
  * @param {?} datum
@@ -222,4 +221,3 @@ function matchType(datum, ruleName, keyName, customMessage) {
   }
 
 }
-

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "validator": "~3.22.0",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "validator": "~3.22.0"
   },
   "devDependencies": {
     "async": "~0.2.10",
-    "mocha": "^2"
+    "mocha": "^2",
+    "should": "^8"
   }
 }

--- a/test/basicType.test.js
+++ b/test/basicType.test.js
@@ -2,8 +2,6 @@ var _ = require('lodash');
 var lusitania = require('../index.js');
 var testType = require('./util/testType.js');
 
-
-
 describe('basic rules', function() {
 
 	it('should create an lusitania object in naive usage',function () {

--- a/test/errorFactory.test.js
+++ b/test/errorFactory.test.js
@@ -1,0 +1,32 @@
+var lusitania = require('../index.js');
+require('should');
+
+describe('error messages', function() {
+  it('null errors should be readable', function() {
+    var result = lusitania(null).to({
+      type: 'number',
+    }, {
+      validation: 'foo'
+    });
+    result.length.should.equal(1);
+    result[0].message.should.equal('`foo` should be a number (instead of null)');
+  });
+
+  it('other type errors should be readable', function() {
+    var result = lusitania('blah').to({
+      type: 'number',
+    }, {
+      validation: 'foo'
+    });
+    result.length.should.equal(1);
+    result[0].message.should.equal('`foo` should be a number (instead of "blah", which is a string)');
+  });
+
+  it('calls it a field if no validation is defined', function() {
+    var result = lusitania('blah').to({
+      type: 'number',
+    }, { });
+    result.length.should.equal(1);
+    result[0].message.should.equal('`field` should be a number (instead of "blah", which is a string)');
+  });
+});

--- a/test/util/testType.js
+++ b/test/util/testType.js
@@ -1,6 +1,6 @@
 var _ = require('lodash');
-var lusitania = require('../../index.js');
 var async = require('async');
+var lusitania = require('../../index.js');
 
 // Test a rule given a deliberate example and nonexample
 // Test WITH and WITHOUT callback


### PR DESCRIPTION
Previously if you passed "null" for a typed field Anchor would return the very
confusing error message

```
`undefined` should be a text (instead of "null", which is a object)
```

Instead now we return the better error message:

```
`foo` should be a number (instead of null)
```

Note this requires you to pass the key `validation` as part of the `context`.
Waterline doesn't do this, yet, but it will soon.

Adds a simple test for both the null case and the regular case.
