### PR TITLE
Don't return an array of errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,8 +40,7 @@ Lusitania.prototype.rules = require('./lib/match/rules');
 
 Lusitania.prototype.to = function (ruleset, context) {
 
-  var errors = [];
-
+  var error = false;
   // If ruleset doesn't contain any explicit rule keys,
   // assume that this is a type
 
@@ -54,32 +53,32 @@ Lusitania.prototype.to = function (ruleset, context) {
   // Look for explicit rules
   for (var rule in ruleset) {
 
+    var result;
     if (rule === 'type') {
 
       // Use deep match to descend into the collection and verify each item and/or key
       // Stop at default maxDepth (50) to prevent infinite loops in self-associations
-      errors = errors.concat(Lusitania.match.type.call(context, this.data, ruleset.type, null, validation));
+      result = Lusitania.match.type.call(context, this.data, ruleset.type, null, validation);
+      if (result) {
+        error = result;
+        break;
+      }
     }
 
     // Validate a non-type rule
     else {
-      errors = errors.concat(Lusitania.match.rule.call(context, this.data, rule, ruleset[rule]));
+      result = Lusitania.match.rule.call(context, this.data, rule, ruleset[rule]);
+      if (result) {
+        error = result;
+        break;
+      }
     }
   }
 
-  // If errors exist, return the list of them
-  if (errors.length) {
-    return errors;
-  }
-
-  // No errors, so return false
-  else return false;
+  return error;
 
 };
 Lusitania.prototype.hasErrors = Lusitania.prototype.to;
-
-
-
 
 
 /**
@@ -107,7 +106,7 @@ coerceValues: function () {}
 }
 *
 * Adapter developers would be able to use Lusitania.prototype.cast()
-* to declaritively define these type coercions.
+* to declaratively define these type coercions.
 
 * Down the line, we could take this further for an even nicer API,
 * but for now, this alone would be a nice improvement.

--- a/lib/match/errorFactory.js
+++ b/lib/match/errorFactory.js
@@ -49,12 +49,11 @@ module.exports = function errorFactory(value, ruleName, keyName, customMessage) 
 
 
   // Construct error object
-  return [{
-    property: keyName,
-    data: value,
-    message: errMsg,
-    rule: ruleName,
-    actualType: typeof value,
-    expectedType: ruleName
-  }];
+  var err = new Error(errMsg);
+  err.property = keyName;
+  err.data = value;
+  err.rule = ruleName;
+  err.actualType = typeof value;
+  err.expectedType = ruleName;
+  return err;
 };

--- a/lib/match/matchRule.js
+++ b/lib/match/matchRule.js
@@ -44,14 +44,11 @@ module.exports = function matchRule (data, ruleName, args) {
 
   // If outcome is false, an error occurred
   if (!outcome) {
-    return [{
-      rule: ruleName,
-      data: data,
-      message: util.format('"%s" validation rule failed for input: %s', ruleName, util.inspect(data))
-    }];
+    var err = new Error(util.format('"%s" validation rule failed for input: %s', ruleName, util.inspect(data)));
+    err.data = data;
+    err.rule = ruleName;
+    return err;
+  } else {
+    return null;
   }
-  else {
-    return [];
-  }
-
 };

--- a/lib/match/matchType.js
+++ b/lib/match/matchType.js
@@ -1,11 +1,12 @@
 /**
  * Module dependencies
  */
-
 var util = require('util');
+
 var _ = require('lodash');
-var rules = require('./rules');
+
 var errorFactory = require('./errorFactory');
+var rules = require('./rules');
 
 // var JSValidationError
 
@@ -33,7 +34,7 @@ var MAX_DEPTH = 50;
  * @param {String} customMessage
  *                   (optional)
  *
- * @returns a list of errors (or an empty list if no errors were found)
+ * @returns an error (or null if no errors were found)
  */
 
 function deepMatchType(data, ruleset, depth, keyName, customMessage) {
@@ -42,9 +43,7 @@ function deepMatchType(data, ruleset, depth, keyName, customMessage) {
   // Prevent infinite recursion
   depth = depth || 0;
   if (depth > MAX_DEPTH) {
-    return [
-      new Error({ message: 'Exceeded MAX_DEPTH when validating object.  Maybe it\'s recursively referencing itself?'})
-    ];
+    return new Error('Exceeded MAX_DEPTH when validating object. Maybe it\'s recursively referencing itself?');
   }
 
   // (1) Base case - primitive
@@ -61,20 +60,35 @@ function deepMatchType(data, ruleset, depth, keyName, customMessage) {
   else if (_.isArray(ruleset)) {
     if (ruleset.length !== 0) {
       if (ruleset.length > 1) {
-        return [
-          new Error({ message: '[] (or schema) rules must contain exactly one item.'})
-        ];
+        return new Error('[] (or schema) rules must contain exactly one item.');
       }
 
+      var err;
+      var datum;
+      if (_.isArray(data)) {
+        for (var i = 0; i < data.length; i++) {
+          datum = data[i];
+          err = deepMatchType.call(self, datum, ruleset[0], depth + 1, keyName, customMessage);
+          if (err) {
+            return err;
+          }
+        }
+      } else {
+        for (datum in data) {
+          err = deepMatchType.call(self, datum, ruleset[0], depth + 1, keyName, customMessage);
+          if (err) {
+            return err;
+          }
+        }
+      }
       // Handle plurals (arrays with a schema rule)
       // Match each object in data array against ruleset until error is detected
-      return _.reduce(data, function getErrors(errors, datum) {
-        errors = errors.concat(deepMatchType.call(self, datum, ruleset[0], depth + 1, keyName, customMessage));
-        return errors;
-      }, []);
+      return false;
     }
     // Leaf rules land here and execute the iterator fn
-    else return matchType.call(self, data, ruleset, keyName, customMessage);
+    else {
+      return matchType.call(self, data, ruleset, keyName, customMessage);
+    }
   }
 
   // (3) Recursive case - POJO
@@ -102,13 +116,12 @@ function deepMatchType(data, ruleset, depth, keyName, customMessage) {
     // Don't allow a `$message` without a `$validate`
     if (_customMessage) {
       if (!subValidation) {
-        return [{
-          code: 'E_USAGE',
-          status: 500,
-          $message: _customMessage,
-          property: keyName,
-          message: 'Custom messages ($message) require a subvalidation - please specify a `$validate` option on `'+keyName+'`'
-        }];
+        var err = new Error('Custom messages ($message) require a subvalidation - please specify a `$validate` option on `'+keyName+'`');
+        err.code = 'E_USAGE';
+        err.status = 500;
+        err.$message = _customMessage;
+        err.property = keyName;
+        return err;
       }
       else {
         // Use the specified message as the `customMessage`
@@ -119,16 +132,11 @@ function deepMatchType(data, ruleset, depth, keyName, customMessage) {
     // Execute subvalidation rules
     if (subValidation) {
       if (!subValidation.type) {
-        return [
-          new Error({message: 'Sub-validation rules (i.e. using $validate) other than `type` are not currently supported'})
-        ];
+        return new Error('Sub-validation rules (i.e. using $validate) other than `type` are not currently supported');
       }
 
       return deepMatchType.call(self, data, subValidation.type, depth+1, keyName, customMessage);
     }
-
-
-
 
 
     // Don't treat empty object as a ruleset
@@ -137,17 +145,18 @@ function deepMatchType(data, ruleset, depth, keyName, customMessage) {
       return matchType.call(self, data, ruleset, keyName, customMessage);
     } else {
       // Iterate through rules in dictionary until error is detected
-      return _.reduce(ruleset, function(errors, subRule, key) {
-
-        // Prevent throwing when encountering unexpectedly "shallow" data
-        // (instead- this should be pushed as an error where "undefined" is
-        // not of the expected type: "object")
+      for (var key in ruleset) {
+        var subRule = ruleset[key];
         if (!_.isObject(data)) {
-          return errors.concat(errorFactory(data, 'object', key, customMessage));
+          return errorFactory(data, 'object', key, customMessage);
         } else {
-          return errors.concat(deepMatchType.call(self, data[key], ruleset[key], depth + 1, key, customMessage));
+          var result = deepMatchType.call(self, data[key], subRule, depth + 1, key, customMessage);
+          if (result) {
+            return result;
+          }
         }
-      }, []);
+      }
+      return false;
     }
   }
 }
@@ -170,9 +179,7 @@ function deepMatchType(data, ruleset, depth, keyName, customMessage) {
  */
 
 function matchType(datum, ruleName, keyName, customMessage) {
-
   var self = this;
-
   try {
     var rule;
     var outcome;
@@ -192,7 +199,7 @@ function matchType(datum, ruleName, keyName, customMessage) {
         // If argument to regex rule is not a string,
         // fail on 'string' validation
         if (!_.isString(x)) {
-          rule = rules['string'];
+          rule = rules.string;
         } else x.match.call(self, ruleName);
       };
     }
@@ -202,9 +209,7 @@ function matchType(datum, ruleName, keyName, customMessage) {
 
     // Determine outcome
     if (!rule) {
-      return [
-        new Error({message:'Unknown rule: ' + ruleName})
-      ];
+      return new Error('Unknown rule: ' + ruleName);
     }
     else outcome = rule.call(self, datum);
 
@@ -214,7 +219,7 @@ function matchType(datum, ruleName, keyName, customMessage) {
     }
 
     // If everything is ok, return an empty list
-    else return [];
+    else return null;
   }
   catch (e) {
     return errorFactory(datum, ruleName, keyName, customMessage);

--- a/test/arrayType.test.js
+++ b/test/arrayType.test.js
@@ -4,127 +4,127 @@ var testType = require('./util/testType.js');
 
 describe('arrays', function() {
 
-	it(' should properly support both flavors of basic array validation rules', function() {
-		testType({
-			name: 'string',
-			id: 'numeric',
-			friends: [],
-			moreFriends: 'array'
-		}, {
-			name: 'Rachael',
-			id: '235',
-			friends: ['a','b'],
-			moreFriends: [{
-				name: 'Rachael'
-			}, {
-				name: 'Sebastian'
-			}, {
-				name: 'Heather'
-			}]
-		}, {
-			name: 'Sebastian',
-			id: '235',
-			friends: 'd'
-		});
-	});
+  it(' should properly support both flavors of basic array validation rules', function() {
+    testType({
+      name: 'string',
+      id: 'numeric',
+      friends: [],
+      moreFriends: 'array'
+    }, {
+      name: 'Rachael',
+      id: '235',
+      friends: ['a', 'b'],
+      moreFriends: [{
+        name: 'Rachael'
+      }, {
+        name: 'Sebastian'
+      }, {
+        name: 'Heather'
+      }]
+    }, {
+      name: 'Sebastian',
+      id: '235',
+      friends: 'd'
+    });
+  });
 
 
-	it(' should properly parse lists defined with schema rule ', function() {
-		testType({
-			name: 'string',
-			id: 'numeric',
+  it('should properly parse lists defined with schema rule', function() {
+    testType({
+      name: 'string',
+      id: 'numeric',
 
-			// Require a collection of friend objects as defined:
-			friends: [{
-				name: 'string',
-				id: 'integer'
-			}]
-		}, {
-			name: 'Rachael',
-			id: '235',
-			friends: [{
-				id: 2,
-				name: 'Mike******************',
-				favoriteColor: 'red'
-			}, {
-				id: 3,
-				name: 'Sebastian'
-			}, {
-				id: 4,
-				name: 'Heather'
-			}]
-		}, {
-			name: 'Sebastian',
-			id: '235',
-			friends: [{
-				id: 2,
-				name: 'Rachael'
-			},{
-				id: "foo",
-				name: 'Sebastian'
-			}]
-		});
-	});
+      // Require a collection of friend objects as defined:
+      friends: [{
+        name: 'string',
+        id: 'integer'
+      }]
+    }, {
+      name: 'Rachael',
+      id: '235',
+      friends: [{
+        id: 2,
+        name: 'Mike******************',
+        favoriteColor: 'red'
+      }, {
+        id: 3,
+        name: 'Sebastian'
+      }, {
+        id: 4,
+        name: 'Heather'
+      }]
+    }, {
+      name: 'Sebastian',
+      id: '235',
+      friends: [{
+        id: 2,
+        name: 'Rachael'
+      },{
+        id: "foo",
+        name: 'Sebastian'
+      }]
+    });
+  });
 
-	it(' should properly parse more complex lists defined with schema rule ', function() {
-		testType({
-			name: 'string',
-			id: 'numeric',
+  it(' should properly parse more complex lists defined with schema rule ', function() {
+    testType({
+      name: 'string',
+      id: 'numeric',
 
-			// Require a collection of friend objects as defined:
-			friends: [{
-				name: 'string',
-				id: 'integer'
-			}]
-		}, {
-			name: 'Rachael',
-			id: '235',
-			friends: [{
-				id: 2,
-				name: 'Mike******************',
-				favoriteColor: 'red'
-			}, {
-				id: 3,
-				name: 'Sebastian',
-				somethingElse: [{a:1,b:3}]
-			}, {
-				id: 4,
-				name: 'Heather',
-				somethingElse: [{a:1,b:5}]
-			}]
-		}, {
-			name: 'Sebastian',
-			id: '235',
-			friends: [{
-				id: 2,
-				name: 'Rachael'
-			},{
-				id: "foo",
-				name: 'Sebastian'
-			}]
-		});
-	});
+      // Require a collection of friend objects as defined:
+      friends: [{
+        name: 'string',
+        id: 'integer'
+      }]
+    }, {
+      name: 'Rachael',
+      id: '235',
+      friends: [{
+        id: 2,
+        name: 'Mike******************',
+        favoriteColor: 'red'
+      }, {
+        id: 3,
+        name: 'Sebastian',
+        somethingElse: [{a:1,b:3}]
+      }, {
+        id: 4,
+        name: 'Heather',
+        somethingElse: [{a:1,b:5}]
+      }]
+    }, {
+      name: 'Sebastian',
+      id: '235',
+      friends: [{
+        id: 2,
+        name: 'Rachael'
+      },{
+        id: "foo",
+        name: 'Sebastian'
+      }]
+    });
+  });
 
 
-	it(' should properly parse top-level lists ', function() {
-		testType([{
-			name: 'string',
-			id: 'int'
-		}], [{
-				id: 2,
-				name: 'Rachael',
-				favoriteColor: 'red'
-			}, {
-				id: 3,
-				name: 'Sebastian'
-			}, {
-				id: 4,
-				name: 'Heather'
-			}], {
-			name: 'Sebastian',
-			id: '235',
-			friends: 'd'
-		});
-	});
+  it('should properly parse top-level lists', function() {
+    testType([{
+      name: 'string',
+      id: 'int'
+    }], [{
+      id: 2,
+      name: 'Rachael',
+      favoriteColor: 'red'
+    }, {
+      id: 3,
+      name: 'Sebastian'
+    }, {
+      id: 4,
+      name: 'Heather'
+    }], {
+      name: 'Sebastian',
+      id: '235',
+      friends: 'd'
+    });
+  });
 
 });

--- a/test/customMessages.test.js
+++ b/test/customMessages.test.js
@@ -1,19 +1,20 @@
-var _ = require('lodash');
-var lusitania = require('../index.js');
-var testType = require('./util/testType.js');
 var assert = require('assert');
 
+var _ = require('lodash');
+require('should');
+
+var lusitania = require('../index.js');
+var testType = require('./util/testType.js');
 
 describe('custom validation messages ($message syntax)', function() {
 
   it(' should use custom validation message when `$message` is a string', function() {
 
-    var errors = lusitania({
+    var error = lusitania({
       name: 'Sebastian',
       id: '235',
       friends: 'd'
-    })
-    .to({
+    }).to({
       type: {
         name: {
           $validate: {
@@ -49,21 +50,13 @@ describe('custom validation messages ($message syntax)', function() {
       }
     });
 
-    var ok = _.all(errors, function (err) {
-      switch(err.property) {
-        case 'name': return err.message === 'oops0';
-        case 'id': return err.message === 'oops1';
-        case 'friends': return err.message === 'oops2';
-        case 'moreFriends': return err.message === 'oops3';
-
-        // Check for proper usage error:
-        case 'foo': return err.status === 500 && err.code === 'E_USAGE' && err.$message === 'oops4';
-        default: return false;
-      }
+    error.message.should.equal('oops2');
+    error.should.have.properties({
+      message: 'oops2',
+      data: 'd',
+      property: 'friends',
+      actualType: 'string',
     });
-
-    assert(ok, 'Failed to use the specified custom validation message(s)');
-
   });
 
 });

--- a/test/errorFactory.test.js
+++ b/test/errorFactory.test.js
@@ -8,8 +8,7 @@ describe('error messages', function() {
     }, {
       validation: 'foo'
     });
-    result.length.should.equal(1);
-    result[0].message.should.equal('`foo` should be a number (instead of null)');
+    result.message.should.equal('`foo` should be a number (instead of null)');
   });
 
   it('other type errors should be readable', function() {
@@ -18,15 +17,13 @@ describe('error messages', function() {
     }, {
       validation: 'foo'
     });
-    result.length.should.equal(1);
-    result[0].message.should.equal('`foo` should be a number (instead of "blah", which is a string)');
+    result.message.should.equal('`foo` should be a number (instead of "blah", which is a string)');
   });
 
   it('calls it a field if no validation is defined', function() {
     var result = lusitania('blah').to({
       type: 'number',
     }, { });
-    result.length.should.equal(1);
-    result[0].message.should.equal('`field` should be a number (instead of "blah", which is a string)');
+    result.message.should.equal('`field` should be a number (instead of "blah", which is a string)');
   });
 });

--- a/test/miscellaneousRules.test.js
+++ b/test/miscellaneousRules.test.js
@@ -6,54 +6,54 @@ var testRules = require('./util/testRules.js');
 
 describe('miscellaneous rules', function() {
 
-	describe ('max/min',function () {
-		it (' should support "max" rule ', function () {
-			return testRules({
-				max: 3
-			},2,5);
-		});
-	});
+  describe ('max/min',function () {
+    it (' should support "max" rule ', function () {
+      return testRules({
+        max: 3
+      },2,5);
+    });
+  });
 
-    describe ('greaterThan/lessThan',function () {
-        it (' should support "greaterThan" rule ', function () {
-            return testRules({
-                greaterThan: 3.5
-            },4,3);
-        });
-        it (' should support "greaterThan" rule ', function () {
-            return testRules({
-                greaterThan: 3.5
-            },3.6,3.5);
-        });
-        it (' should support "lessThan" rule ', function () {
-            return testRules({
-                lessThan: 3.5
-            },3,4);
-        });
-        it (' should support "lessThan" rule ', function () {
-            return testRules({
-                lessThan: 3.5
-            },3.4,3.5);
-        });
+  describe ('greaterThan/lessThan',function () {
+    it (' should support "greaterThan" rule ', function () {
+      return testRules({
+        greaterThan: 3.5
+      },4,3);
+    });
+    it (' should support "greaterThan" rule ', function () {
+      return testRules({
+        greaterThan: 3.5
+      },3.6,3.5);
+    });
+    it (' should support "lessThan" rule ', function () {
+      return testRules({
+        lessThan: 3.5
+      },3,4);
+    });
+    it (' should support "lessThan" rule ', function () {
+      return testRules({
+        lessThan: 3.5
+      },3.4,3.5);
+    });
+  });
+
+  describe('url', function () {
+
+    it ('should support "url" rule with no options', function () {
+      return testRules({ url: true }, 'http://sailsjs.org', 'sailsjs');
     });
 
-	describe('url', function () {
+    it ('should support "url" rule with options', function () {
+      return testRules({ url: { require_protocol: true } }, 'http://sailsjs.org', 'www.sailsjs.org');
+    });
+  });
 
-		it ('should support "url" rule with no options', function () {
-			return testRules({ url: true }, 'http://sailsjs.org', 'sailsjs');
-		});
-
-		it ('should support "url" rule with options', function () {
-			return testRules({ url: { require_protocol: true } }, 'http://sailsjs.org', 'www.sailsjs.org');
-		});
-	});
-
-	describe('before/after date', function () {
-		it (' should support "before" rule ', function () {
-			return testRules({
-				before: new Date()
-			},new Date(Date.now() - 100000),new Date(Date.now() + 1000000));
-		});
-	});
+  describe('before/after date', function () {
+    it (' should support "before" rule ', function () {
+      return testRules({
+        before: new Date()
+      },new Date(Date.now() - 100000),new Date(Date.now() + 1000000));
+    });
+  });
 
 });

--- a/test/util/testRules.js
+++ b/test/util/testRules.js
@@ -1,30 +1,30 @@
 var _ = require('lodash');
+
 var lusitania = require('../../index.js');
-var async = require('async');
 
 // Test a rule given a deliberate example and nonexample
 // Test WITH and WITHOUT callback
 module.exports = function testRules (rules, example, nonexample) {
 
-	// Throw an error if there's any trouble
-	// (not a good production usage pattern-- just here for testing)
-	var exampleOutcome, nonexampleOutcome;
+  // Throw an error if there's any trouble
+  // (not a good production usage pattern-- just here for testing)
+  var exampleOutcome, nonexampleOutcome;
 
-	// Should be falsy
-	exampleOutcome = lusitania(example).to(rules);
+  // Should be falsy
+  exampleOutcome = lusitania(example).to(rules);
 
-	// Should be an array
-	nonexampleOutcome = lusitania(nonexample).to(rules);
+  // Should be an array
+  nonexampleOutcome = lusitania(nonexample).to(rules);
 
-	if (exampleOutcome) {
-		return gotErrors('Valid input marked with error!', exampleOutcome, example);
-	}
-	if (!_.isArray(nonexampleOutcome)) {
-		return gotErrors('Invalid input (' + nonexample + ') allowed through.',
-			rules, nonexample);
-	}
+  if (exampleOutcome) {
+    return gotErrors('Valid input marked with error!', exampleOutcome, example);
+  }
+  if (! (nonexampleOutcome instanceof Error)) {
+    return gotErrors('Invalid input (' + nonexample + ') allowed through.',
+    rules, nonexample);
+  }
 
-	function gotErrors (errMsg, err, data) {
-		throw new Error(errMsg);
-	}
+  function gotErrors (errMsg, err, data) {
+    throw new Error(errMsg);
+  }
 };

--- a/test/util/testType.js
+++ b/test/util/testType.js
@@ -23,16 +23,11 @@ module.exports = function testType (rule, example, nonexample) {
 	if (exampleOutcome) {
 		return gotErrors(exampleOutcome);
 	}
-	if (!_.isArray(nonexampleOutcome)) {
-		return gotErrors('Invalid input (' + nonexample + ') allowed through as a ' + rule + '.');
+	if (!(nonexampleOutcome instanceof Error)) {
+		return gotErrors('Invalid input (' + JSON.stringify(nonexample) + ') allowed through as a ' + JSON.stringify(rule) + '.');
 	}
 
 	function gotErrors (err) {
-		console.error('*****************');
-		console.error('err', err);
-		console.error('nonexampleOutcome', nonexampleOutcome);
-		console.error('nonexample', nonexample);
-		console.error('rule', rule);
 		throw new Error(err);
 	}
 };


### PR DESCRIPTION
If more than one thing breaks, too bad; just return the first validation error,
instead of all of them. This will simplify the programming model and the error
handling model in Waterline/Sails significantly.

Furthermore, properly initialize and pass back Error objects. The previous
error constructor incorrectly initialized the Error constructor with a
dictionary instead of an error message, which would lead to Error: [object
Object] being created instead of an error message.

We should be throwing errors instead of returning an Error or null, but that
will have to come in a later commit since this is big enough already.
