### PR TITLE
Return a slightly better message for invalid rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,8 +60,7 @@ Lusitania.prototype.to = function (ruleset, context) {
       // Stop at default maxDepth (50) to prevent infinite loops in self-associations
       result = Lusitania.match.type.call(context, this.data, ruleset.type, null, validation);
       if (result) {
-        error = result;
-        break;
+        return result;
       }
     }
 
@@ -69,8 +68,7 @@ Lusitania.prototype.to = function (ruleset, context) {
     else {
       result = Lusitania.match.rule.call(context, this.data, rule, ruleset[rule]);
       if (result) {
-        error = result;
-        break;
+        return result;
       }
     }
   }

--- a/lib/match/matchRule.js
+++ b/lib/match/matchRule.js
@@ -10,12 +10,11 @@ var rules = require('./rules');
 /**
  * Match a miscellaneous rule
  * Returns an empty list on success,
- * or a list of errors if things go wrong
+ * or an error if things go wrong
  */
 
 module.exports = function matchRule (data, ruleName, args) {
-  var self = this,
-    errors = [];
+  var self = this;
 
   // if args is an array we need to make it a nested array
   if (Array.isArray(args)) {
@@ -44,7 +43,14 @@ module.exports = function matchRule (data, ruleName, args) {
 
   // If outcome is false, an error occurred
   if (!outcome) {
-    var err = new Error(util.format('"%s" validation rule failed for input: %s', ruleName, util.inspect(data)));
+    var fieldName;
+    if (typeof this.validation === 'undefined' || this.validation === null) {
+      fieldName = 'field';
+    } else {
+      fieldName = this.validation;
+    }
+    var err = new Error(util.format('Invalid %s. Input failed %s validation: %s', fieldName, ruleName, util.inspect(data)));
+
     err.data = data;
     err.rule = ruleName;
     return err;

--- a/lib/match/rules.js
+++ b/lib/match/rules.js
@@ -5,12 +5,11 @@
 var _ = require('lodash');
 var validator = require('validator');
 
-
-
 /**
- * Type rules
+ * Type rules. Currently these are a function which return false if the value
+ * fails validation. In the future they should return null or throw an error -
+ * that way each function can provide its own error message.
  */
-
 module.exports = {
 
 	'empty'		: _.isEmpty,

--- a/test/miscellaneousRules.test.js
+++ b/test/miscellaneousRules.test.js
@@ -1,8 +1,8 @@
+var should = require('should');
 var _ = require('lodash');
+
 var lusitania = require('../index.js');
 var testRules = require('./util/testRules.js');
-
-
 
 describe('miscellaneous rules', function() {
 
@@ -10,7 +10,17 @@ describe('miscellaneous rules', function() {
     it (' should support "max" rule ', function () {
       return testRules({
         max: 3
-      },2,5);
+      }, 2, 5);
+    });
+
+    it('should return a good error message', function() {
+      var context = {
+        validation: 'day',
+      };
+      l = lusitania(27);
+      result = l.to({ type: 'integer', required: true, min: 0, max: 24 }, context);
+      result.should.be.instanceof(Error);
+      result.message.should.equal('Invalid day. Input failed max validation: 27');
     });
   });
 

--- a/test/util/testRules.js
+++ b/test/util/testRules.js
@@ -13,7 +13,7 @@ module.exports = function testRules (rules, example, nonexample) {
   // Should be falsy
   exampleOutcome = lusitania(example).to(rules);
 
-  // Should be an array
+  // Should be an Error
   nonexampleOutcome = lusitania(nonexample).to(rules);
 
   if (exampleOutcome) {
@@ -21,7 +21,7 @@ module.exports = function testRules (rules, example, nonexample) {
   }
   if (! (nonexampleOutcome instanceof Error)) {
     return gotErrors('Invalid input (' + nonexample + ') allowed through.',
-    rules, nonexample);
+      rules, nonexample);
   }
 
   function gotErrors (errMsg, err, data) {


### PR DESCRIPTION
Really, each rule in lib/match/rules.js should throw an error on invalid input,
so you can say things like "The maximum allowed value is 5 (input: 6)" or
whatever, instead of having one rule apply to everything.

But this should be a slight improvement - specifically, we now include the
column name in the error message, if we have it. An error message that looked
like this:

```
"min" validation rule failed for input: -1
```

Now looks like this:

```
Invalid day. Input failed min validation: -1
```

Still not great, but better, and includes the column name.
