### PR TITLE
Special case 'required' rule

### DIFF
--- a/lib/match/matchRule.js
+++ b/lib/match/matchRule.js
@@ -49,7 +49,13 @@ module.exports = function matchRule (data, ruleName, args) {
     } else {
       fieldName = this.validation;
     }
-    var err = new Error(util.format('Invalid %s. Input failed %s validation: %s', fieldName, ruleName, util.inspect(data)));
+
+    var err;
+    if (ruleName === 'required') {
+      err = new Error(util.format('No %s was provided. Please provide a %s', fieldName, fieldName));
+    } else {
+      err = new Error(util.format('Invalid %s. Input failed %s validation: %s', fieldName, ruleName, util.inspect(data)));
+    }
 
     err.data = data;
     err.rule = ruleName;

--- a/lib/match/rules.js
+++ b/lib/match/rules.js
@@ -1,115 +1,119 @@
 /**
- * Module dependencies
- */
+* Module dependencies
+*/
 
 var _ = require('lodash');
 var validator = require('validator');
 
 /**
- * Type rules. Currently these are a function which return false if the value
- * fails validation. In the future they should return null or throw an error -
- * that way each function can provide its own error message.
- */
+* Type rules. Currently these are a function which return false if the value
+* fails validation. In the future they should return null or throw an error -
+* that way each function can provide its own error message.
+*/
 module.exports = {
 
-	'empty'		: _.isEmpty,
+  'empty' : _.isEmpty,
 
-	'required'	: function (x) {
-		// Transform data to work properly with node validator
-		if(!x && x !== 0) x = '';
-		else if(typeof x.toString !== 'undefined') x = x.toString();
-		else x = '' + x;
+  'required' : function (x) {
+    // Transform data to work properly with node validator
+    if (!x && x !== 0) {
+      x = '';
+    } else if (typeof x.toString !== 'undefined') {
+      x = x.toString();
+    } else {
+      x = '' + x;
+    }
 
-		return !validator.isNull(x);
-	},
+    return !validator.isNull(x);
+  },
 
-	'protected'	: function () {return true;},
+  'protected' : function () {return true;},
 
-	'notEmpty'	: function (x) {
+  'notEmpty' : function (x) {
 
-		// Transform data to work properly with node validator
-		if (!x) x = '';
-		else if (typeof x.toString !== 'undefined') x = x.toString();
-		else x = '' + x;
+    // Transform data to work properly with node validator
+    if (!x) x = '';
+    else if (typeof x.toString !== 'undefined') x = x.toString();
+    else x = '' + x;
 
-		return !validator.isNull(x);
-	},
+    return !validator.isNull(x);
+  },
 
-	'undefined'	: _.isUndefined,
+  'undefined'	: _.isUndefined,
 
-	'object'  : _.isObject,
-	'json'    : function (x) {
-		if (_.isUndefined(x)) return false;
-		try { JSON.stringify(x); }
-		catch(err) { return false; }
-		return true;
-	},
-	'mediumtext'	: _.isString,
-	'text'		: _.isString,
-	'string'	: _.isString,
-	'alpha'		: validator.isAlpha,
-	'alphadashed': function (x) {return (/^[a-zA-Z-_]*$/).test(x); },
-	'numeric'	: validator.isNumeric,
-	'alphanumeric': validator.isAlphanumeric,
-	'alphanumericdashed': function (x) {return (/^[a-zA-Z0-9-_]*$/).test(x); },
-	'email'		: validator.isEmail,
-	'url'		: function(x, opt) { return validator.isURL(x, opt === true ? undefined : opt); },
-	'urlish'	: /^\s([^\/]+\.)+.+\s*$/g,
-	'ip'			: validator.isIP,
-	'ipv4'		: validator.isIPv4,
-	'ipv6'		: validator.isIPv6,
-	'creditcard': validator.isCreditCard,
-	'uuid'		: validator.isUUID,
-	'uuidv3'	: function (x){ return validator.isUUID(x, 3);},
-	'uuidv4'	: function (x){ return validator.isUUID(x, 4);},
+  'object'  : _.isObject,
+  'json'    : function (x) {
+    if (_.isUndefined(x)) return false;
+    try { JSON.stringify(x); }
+    catch(err) { return false; }
+    return true;
+  },
+  'mediumtext'	: _.isString,
+  'text'		: _.isString,
+  'string'	: _.isString,
+  'alpha'		: validator.isAlpha,
+  'alphadashed': function (x) {return (/^[a-zA-Z-_]*$/).test(x); },
+  'numeric'	: validator.isNumeric,
+  'alphanumeric': validator.isAlphanumeric,
+  'alphanumericdashed': function (x) {return (/^[a-zA-Z0-9-_]*$/).test(x); },
+  'email'		: validator.isEmail,
+  'url'		: function(x, opt) { return validator.isURL(x, opt === true ? undefined : opt); },
+  'urlish'	: /^\s([^\/]+\.)+.+\s*$/g,
+  'ip'			: validator.isIP,
+  'ipv4'		: validator.isIPv4,
+  'ipv6'		: validator.isIPv6,
+  'creditcard': validator.isCreditCard,
+  'uuid'		: validator.isUUID,
+  'uuidv3'	: function (x){ return validator.isUUID(x, 3);},
+  'uuidv4'	: function (x){ return validator.isUUID(x, 4);},
 
-	'int'			: validator.isInt,
-	'integer'	: validator.isInt,
-	'number'	: _.isNumber,
-	'finite'	: _.isFinite,
+  'int'			: validator.isInt,
+  'integer'	: validator.isInt,
+  'number'	: _.isNumber,
+  'finite'	: _.isFinite,
 
-	'decimal'	: validator.isFloat,
-	'float'		: validator.isFloat,
+  'decimal'	: validator.isFloat,
+  'float'		: validator.isFloat,
 
-	'falsey'	: function (x) { return !x; },
-	'truthy'	: function (x) { return !!x; },
-	'null'		: _.isNull,
-	'notNull'	: function (x) { return !validator.isNull(x); },
+  'falsey'	: function (x) { return !x; },
+  'truthy'	: function (x) { return !!x; },
+  'null'		: _.isNull,
+  'notNull'	: function (x) { return !validator.isNull(x); },
 
-	'boolean'	: _.isBoolean,
+  'boolean'	: _.isBoolean,
 
-	'array'		: _.isArray,
+  'array'		: _.isArray,
 
-	'binary'	: function (x) { return Buffer.isBuffer(x) || _.isString(x); },
+  'binary'	: function (x) { return Buffer.isBuffer(x) || _.isString(x); },
 
-	'date'		: validator.isDate,
-	'datetime': validator.isDate,
+  'date'		: validator.isDate,
+  'datetime': validator.isDate,
 
-	'hexadecimal': validator.hexadecimal,
-	'hexColor': validator.isHexColor,
+  'hexadecimal': validator.hexadecimal,
+  'hexColor': validator.isHexColor,
 
-	'lowercase': validator.isLowercase,
-	'uppercase': validator.isUppercase,
+'lowercase': validator.isLowercase,
+'uppercase': validator.isUppercase,
 
-	// Miscellaneous rules
-	'after'		: validator.isAfter,
-	'before'	: validator.isBefore,
+  // Miscellaneous rules
+  'after'		: validator.isAfter,
+  'before'	: validator.isBefore,
 
-	'equals'	: validator.equals,
-	'contains': validator.contains,
-	'notContains': function (x, str) { return !validator.contains(x, str); },
-	'len'			: function (x, min, max) { return validator.len(x, min, max); },
-	'in'			: validator.isIn,
-	'notIn'		: function (x, arrayOrString) { return !validator.isIn(x, arrayOrString); },
-	'max'			: function (x, val) {
-		var number = parseFloat(x);
-		return isNaN(number) || number <= val;
-	},
-	'min'			: function (x, val) {
-		var number = parseFloat(x);
-		return isNaN(number) || number >= val;
-	},
-	'greaterThan' : function (x, val) {
+  'equals'	: validator.equals,
+  'contains': validator.contains,
+  'notContains': function (x, str) { return !validator.contains(x, str); },
+  'len'			: function (x, min, max) { return validator.len(x, min, max); },
+  'in'			: validator.isIn,
+  'notIn'		: function (x, arrayOrString) { return !validator.isIn(x, arrayOrString); },
+  'max'			: function (x, val) {
+    var number = parseFloat(x);
+    return isNaN(number) || number <= val;
+  },
+  'min'			: function (x, val) {
+    var number = parseFloat(x);
+    return isNaN(number) || number >= val;
+  },
+  'greaterThan' : function (x, val) {
     var number = parseFloat(x);
     return isNaN(number) || number > val;
   },
@@ -117,10 +121,10 @@ module.exports = {
     var number = parseFloat(x);
     return isNaN(number) || number < val;
   },
-	'minLength'	: function (x, min) { return validator.isLength(x, min); },
-	'maxLength'	: function (x, max) { return validator.isLength(x, 0, max); },
+  'minLength'	: function (x, min) { return validator.isLength(x, min); },
+  'maxLength'	: function (x, max) { return validator.isLength(x, 0, max); },
 
-	'regex' : function (x, regex) { return validator.matches(x, regex); },
-	'notRegex' : function (x, regex) { return !validator.matches(x, regex); }
+  'regex' : function (x, regex) { return validator.matches(x, regex); },
+  'notRegex' : function (x, regex) { return !validator.matches(x, regex); }
 
 };

--- a/test/miscellaneousRules.test.js
+++ b/test/miscellaneousRules.test.js
@@ -1,3 +1,5 @@
+var util = require('util');
+
 var should = require('should');
 var _ = require('lodash');
 
@@ -5,6 +7,28 @@ var lusitania = require('../index.js');
 var testRules = require('./util/testRules.js');
 
 describe('miscellaneous rules', function() {
+  describe('required', function() {
+    it('fails for various empty inputs', function() {
+      var emptyInputs = [
+        '',
+        false,
+        null,
+        undefined,
+        [],
+        // FWIW 0 is an allowable value
+      ];
+      var context = {
+        validation: 'email',
+      };
+      for (var i = 0; i < emptyInputs.length; i++) {
+        var val = emptyInputs[i];
+        l = lusitania(val);
+        result = l.to({ required: true }, context);
+        result.should.be.instanceof(Error, util.inspect(val) + " should fail required validation, but didn't");
+        result.message.should.equal('No email was provided. Please provide a email');
+      }
+    });
+  });
 
   describe ('max/min',function () {
     it (' should support "max" rule ', function () {


### PR DESCRIPTION
It comes up often enough that it's worth adding a better error message for this
case - in this instance, "No email was provided. Please provide a email" is
better than "Invalid name. Input failed required validation: ''", when
"required validation" can read as one phrase instead of "required" as the
validation type.

Adds better formatting in lib/match/rules.js and removes a lot of the tabbing
in that file.
